### PR TITLE
(GH-14) Transition from SCSS variables to CSS Variables

### DIFF
--- a/assets/scss/blog/_nav.scss
+++ b/assets/scss/blog/_nav.scss
@@ -3,11 +3,11 @@ aside.blog-nav {
   left: 0;
   position: fixed;
   height: 100%;
-  top: $site-nav-height;
+  top: var(--site-nav-height);
   z-index: 1;
   float: left;
   @media screen and (max-width: 1069px) {
-    height: $blog-nav-height;
+    height: var(--blog-nav-height);
 
     &.wide {
       width: 100%;
@@ -18,8 +18,8 @@ aside.blog-nav {
     height: 100%;
   }
   nav#blog-nav {
-    background-color: $primary-color;
-    color: $primary-color-text;
+    background-color: var(--primary-color);
+    color: var(--primary-color-text);
     padding-left: 1em;
 
     @media screen and (min-width: 1070px) {
@@ -27,7 +27,7 @@ aside.blog-nav {
     }
 
     a {
-      color: $primary-color-text;
+      color: var(--primary-color-text);
       text-decoration: none;
     }
     /* Force accessible focus state */
@@ -35,7 +35,7 @@ aside.blog-nav {
       box-sizing: content-box;
 
       &:focus {
-        background-color: $primary-color-light !important;
+        background-color: var(--primary-color-light) !important;
       }
     }
 
@@ -50,8 +50,8 @@ aside.blog-nav {
     }
 
     button {
-      color: $primary-color-text;
-      background-color: $primary-color;
+      color: var(--primary-color-text);
+      background-color: var(--primary-color);
     }
 
     > .menu-toggle {
@@ -106,7 +106,7 @@ aside.blog-nav {
     }
 
     .menu {
-      background-color: $primary-color;
+      background-color: var(--primary-color);
       list-style: none;
       padding: 0;
       margin: 0;
@@ -133,26 +133,26 @@ aside.blog-nav {
       .menu-link,
       .menu-toggle {
         display: block;
-        background-color: $primary-color;
+        background-color: var(--primary-color);
         text-decoration: none;
         border: none;
         padding: 1rem 2rem;
 
         &:hover {
-          background-color: $primary-color-hover;
+          background-color: var(--primary-color-hover);
         }
       }
 
       &.current {
-        background-color: $primary-color-light;
+        background-color: var(--primary-color-light);
         .menu-link,
         .menu-toggle {
-          background-color: $primary-color-light;
+          background-color: var(--primary-color-light);
         }
       }
 
       .menu-link:active {
-        background-color: $primary-color-light;
+        background-color: var(--primary-color-light);
       }
 
       .menu-item {

--- a/assets/scss/blog/_pagination.scss
+++ b/assets/scss/blog/_pagination.scss
@@ -10,15 +10,15 @@ nav.pagination {
     li {
       a {
         padding: 1em;
-        margin: 0 .5em;
+        margin: 0 0.5em;
         &[aria-current="true"] {
           font-weight: bold;
-          background-color: $primary-color;
-          color: $primary-color-text;
+          background-color: var(--primary-color);
+          color: var(--primary-color-text);
         }
         &:hover {
-          background-color: $primary-color-hover;
-          color: $primary-color-text;
+          background-color: var(--primary-color-hover);
+          color: var(--primary-color-text);
         }
         &[aria-disabled="true"] {
           color: gray;

--- a/assets/scss/games/_nav.scss
+++ b/assets/scss/games/_nav.scss
@@ -3,11 +3,11 @@ aside.game-nav {
   left: 0;
   position: fixed;
   height: 100%;
-  top: $site-nav-height;
+  top: var(--site-nav-height);
   z-index: 1;
   float: left;
   @media screen and (max-width: 1069px) {
-    height: $game-nav-height;
+    height: var(--game-nav-height);
 
     &.wide {
       width: 100%;
@@ -18,8 +18,8 @@ aside.game-nav {
     height: 100%;
   }
   nav#game-nav {
-    background-color: $primary-color;
-    color: $primary-color-text;
+    background-color: var(--primary-color);
+    color: var(--primary-color-text);
     padding-left: 1em;
 
     @media screen and (min-width: 1070px) {
@@ -27,7 +27,7 @@ aside.game-nav {
     }
 
     a {
-      color: $primary-color-text;
+      color: var(--primary-color-text);
       text-decoration: none;
     }
     /* Force accessible focus state */
@@ -35,7 +35,7 @@ aside.game-nav {
       box-sizing: content-box;
 
       &:focus {
-        background-color: $primary-color-light !important;
+        background-color: var(--primary-color-light) !important;
       }
     }
 
@@ -50,13 +50,13 @@ aside.game-nav {
       }
 
       &.current {
-        background-color: $secondary-color;
+        background-color: var(--secondary-color);
       }
     }
 
     button {
-      color: $primary-color-text;
-      background-color: $primary-color;
+      color: var(--primary-color-text);
+      background-color: var(--primary-color);
     }
 
     > .menu-toggle {
@@ -111,7 +111,7 @@ aside.game-nav {
     }
 
     .menu {
-      background-color: $primary-color;
+      background-color: var(--primary-color);
       list-style: none;
       padding: 0;
       margin: 0;
@@ -137,18 +137,18 @@ aside.game-nav {
       .menu-link,
       .menu-toggle {
         display: block;
-        background-color: $primary-color;
+        background-color: var(--primary-color);
         text-decoration: none;
         border: none;
         padding: 1rem 2rem;
 
         &:hover {
-          background-color: $primary-color-hover;
+          background-color: var(--primary-color-hover);
         }
       }
 
       .menu-link:active {
-        background-color: $primary-color-light;
+        background-color: var(--primary-color-light);
       }
 
       .menu-item {

--- a/assets/scss/games/_override.scss
+++ b/assets/scss/games/_override.scss
@@ -1,44 +1,44 @@
 main.#{$name} {
   aside.game-nav {
     nav#game-nav {
-      background-color: $primary-color;
-      color: $primary-color-text;
+      background-color: var(--primary-color);
+      color: var(--primary-color-text);
 
       a {
-        color: $primary-color-text;
+        color: var(--primary-color-text);
       }
       * {
         &:focus {
-          background-color: $primary-color-light !important;
+          background-color: var(--primary-color-light) !important;
         }
       }
 
       button {
-        color: $primary-color-text;
-        background-color: $primary-color;
+        color: var(--primary-color-text);
+        background-color: var(--primary-color);
       }
 
       .menu {
-        background-color: $primary-color;
+        background-color: var(--primary-color);
         &.current {
-          background-color: $primary-color-light;
+          background-color: var(--primary-color-light);
           .menu-link,
           .menu-toggle {
-            background-color: $primary-color-light;
+            background-color: var(--primary-color-light);
           }
         }
 
         .menu-link,
         .menu-toggle {
-          background-color: $primary-color;
+          background-color: var(--primary-color);
 
           &:hover {
-            background-color: $primary-color-hover;
+            background-color: var(--primary-color-hover);
           }
         }
 
         .menu-link:active {
-          background-color: $primary-color-light;
+          background-color: var(--primary-color-light);
         }
       }
     }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,42 +1,50 @@
 // Global defaults
-$font-stack: Helvetica, sans-serif;
-$primary-color: #00b3b3;
-$primary-color-text: #FFF;
-$primary-color-light: #7fd9d9;
-$primary-color-hover: #6bd3d3;
-$secondary-color: #b300b3;
-$secondary-color-text: #FFF;
-$secondary-color-light: #d97fd9;
-$secondary-color-hover: #d36bd3;
-$tertiary-color: #b3b300;
-$tertiary-color-text: #FFF;
-$tertiary-color-light: #d9d97f;
-$tertiary-color-hover: #d3d36b;
-$site-nav-height: 4em;
+:root {
+  --font-stack: Helvetica, sans-serif;
+  --site-nav-height: 4em;
+  --primary-color: #00b3b3;
+  --primary-color-text: #FFF;
+  --primary-color-light: #7fd9d9;
+  --primary-color-hover: #6bd3d3;
+  --secondary-color: #b300b3;
+  --secondary-color-text: #FFF;
+  --secondary-color-light: #d97fd9;
+  --secondary-color-hover: #d36bd3;
+  --tertiary-color: #b3b300;
+  --tertiary-color-text: #FFF;
+  --tertiary-color-light: #d9d97f;
+  --tertiary-color-hover: #d3d36b;
+  --blog-nav-height: 4em;
+  --game-nav-height: 4em;
+}
 // Override Site variables from config
 {{ with .Site.Params.scss.site }}
   {{ range $variable, $value := . }}
-    ${{ $variable}}: {{ $value }};
+    :root {
+      --{{ $variable }}: {{ $value }}
+    }
   {{ end }}
 {{ end }}
 // Site SCSS
 @import 'site';
 // Blog SCSS
-$blog-nav-height: 4em;
 // Override blog defaults from site config
 {{ with .Site.Params.scss.blog }}
   {{ range $variable, $value := . }}
-    ${{ $variable }}: {{ $value }};
+    :root {
+      --{{ $variable }}: {{ $value }}
+    }
   {{ end }}
 {{ end }}
 @import 'blog';
 // Store SCSS
 // Game Variables inherit from site unless overridden
-$game-nav-height: 4em;
 // Override game defaults from site config
 {{ with .Site.Params.scss.games }}
   {{ range $variable, $value := . }}
-    ${{ $variable }}: {{ $value }};
+    :root {
+      --{{ $variable }}: {{ $value }}
+    }
   {{ end }}
 {{ end }}
 // Game SCSS
@@ -48,7 +56,9 @@ $game-nav-height: 4em;
   {{ $name := lower (urlize .Title) }}
   {{ with .Params.scss }}
     {{ range $variable, $value := . }}
-      ${{ $variable }}: {{ $value }};
+      :root {
+        --{{ $variable }}: {{ $value }}
+      }
     {{ end }}
     $name: "{{ $name }}";
     // Import the general variable override
@@ -56,6 +66,6 @@ $game-nav-height: 4em;
   {{ end }}
   body > footer::after {
     content: "{{ resources.Get (printf "scss/%v.scss" $name) }}";
-    color: $primary-color;
+    color: var(--primary-color);
   }
 {{ end }}

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1,11 +1,11 @@
-@import 'site/nav';
-@import 'site/icons';
-@import 'site/details';
-@import 'site/rolltable';
-@import 'site/art';
+@import "site/nav";
+@import "site/icons";
+@import "site/details";
+@import "site/rolltable";
+@import "site/art";
 
 html {
-  font-family: $font-stack;
+  font-family: var(--font-stack);
   font-size: 1rem;
   line-height: 1.2rem;
 }
@@ -22,7 +22,7 @@ footer {
 main {
   width: 100%;
   min-height: 100vh;
-  padding-top: $site-nav-height;
+  padding-top: var(--site-nav-height);
 
   @media screen and (min-width: 1070px) {
     width: 80%;

--- a/assets/scss/site/_nav.scss
+++ b/assets/scss/site/_nav.scss
@@ -5,41 +5,41 @@ header#site-header {
   padding-top: 0;
   z-index: 2;
   a {
-    color: $primary-color-text;
+    color: var(--primary-color-text);
     text-decoration: none;
   }
   /* Force accessible focus state */
   * {
     box-sizing: content-box;
-    
+
     &:focus {
-      background-color: $primary-color-light !important;
+      background-color: var(--primary-color-light) !important;
     }
   }
   nav {
-    height: $site-nav-height;
+    height: var(--site-nav-height);
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
-    background-color: $primary-color;
-    color: $primary-color-text;
+    background-color: var(--primary-color);
+    color: var(--primary-color-text);
   }
-  
+
   #site-nav {
     > .menu {
       display: none;
       flex-direction: column;
-  
+
       &.show {
         display: flex;
       }
     }
 
     button {
-      color: $primary-color-text;
+      color: var(--primary-color-text);
     }
-  
+
     > .menu-toggle {
       display: block;
       margin-left: auto;
@@ -48,31 +48,31 @@ header#site-header {
       font-size: 2rem;
       padding: 0.5rem 2rem;
     }
-  
+
     > .branding {
       display: block;
       font-size: 1.5rem;
       padding: 0.5rem 2rem;
     }
-  
+
     @media screen and (max-width: 1069px) {
       > .menu {
         width: 100%;
       }
     }
-  
+
     @media screen and (min-width: 1070px) {
       > .menu {
         display: flex;
         flex-direction: row;
       }
-  
+
       > .menu-toggle {
         display: none;
       }
     }
   }
-  
+
   .visually-hidden {
     position: absolute !important;
     width: 1px !important;
@@ -84,19 +84,19 @@ header#site-header {
     white-space: nowrap !important;
     border: 0 !important;
   }
-  
+
   .menu {
     display: flex;
     flex-direction: row;
-    background-color: $primary-color;
+    background-color: var(--primary-color);
     list-style: none;
     padding: 0;
     margin: 0;
-  
+
     &.dropdown {
       display: none;
       flex-direction: column;
-  
+
       @media screen and (min-width: 1070px) {
         li.menu-item .menu.dropdown {
           top: 0;
@@ -104,46 +104,46 @@ header#site-header {
         }
       }
     }
-  
+
     @media screen and (max-width: 1069px) {
       .menu .menu-link {
         padding-left: 3rem;
       }
-  
+
       .menu .menu .menu-link {
         padding-left: 4rem;
       }
     }
-  
+
     .menu-link,
     .menu-toggle {
       display: block;
-      background-color: $primary-color;
+      background-color: var(--primary-color);
       text-decoration: none;
       border: none;
       padding: 1rem 2rem;
-  
+
       &:hover {
-        background-color: $primary-color-hover;
+        background-color: var(--primary-color-hover);
       }
     }
-  
+
     .menu-link:active {
-      background-color: $primary-color-light;
+      background-color: var(--primary-color-light);
     }
-  
+
     .menu-item {
       position: relative;
-  
+
       &.dropdown > .dropdown-toggle::after {
         content: "▼";
         margin-left: 0.5rem;
         display: inline-block;
       }
-  
+
       .menu.dropdown.show {
         display: flex;
-  
+
         @media screen and (min-width: 1070px) {
           position: absolute;
           left: 0;

--- a/assets/scss/site/_rolltable.scss
+++ b/assets/scss/site/_rolltable.scss
@@ -3,31 +3,31 @@ table.rolltable {
   th {
     text-align: center;
     font-weight: bold;
-    background-color: $primary-color;
-    color: $primary-color-text;
+    background-color: var(--primary-color);
+    color: var(--primary-color-text);
   }
   th:hover,
   td:hover {
-    background-color: $primary-color-hover;
-    color: $primary-color-text;
+    background-color: var(--primary-color-hover);
+    color: var(--primary-color-text);
   }
   td {
     text-align: center;
     border: 0;
     &.selected {
-      background-color: $primary-color;
-      color: $primary-color-text;
+      background-color: var(--primary-color);
+      color: var(--primary-color-text);
       font-weight: bold;
     }
   }
   tr:nth-child(even) {
-    background-color: $primary-color-light;
+    background-color: var(--primary-color-light);
   }
 
   caption {
     button {
       padding: 5px;
-      color: $primary-color-hover;
+      color: var(--primary-color-hover);
       float: left;
       left: 10px;
     }

--- a/layouts/shortcodes/art.html
+++ b/layouts/shortcodes/art.html
@@ -10,7 +10,7 @@
 
 {{- $src     := $.Scratch.Get "src" -}}
 {{- $alt     := $.Scratch.Get "alt" | default nil -}}
-{{- $class     := $.Scratch.Get "class" | default "full" -}}
+{{- $class   := $.Scratch.Get "class" | default "full" -}}
 {{- $caption := .Inner | default nil -}}
 
 {{- if eq $alt nil -}}

--- a/layouts/shortcodes/detail.html
+++ b/layouts/shortcodes/detail.html
@@ -6,8 +6,8 @@
   {{- $.Scratch.Set "title" (.Get 1) -}}
 {{- end -}}
 
-{{- $type := $.Scratch.Get "type" -}}
-{{- $title := $.Scratch.Get "title" -}}
+{{- $type   := $.Scratch.Get "type" -}}
+{{- $title  := $.Scratch.Get "title" -}}
 {{- $anchor := urlize $title -}}
 
 <details class="{{ $type }}">

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -4,6 +4,6 @@
   {{- $.Scratch.Set "icon"  (.Get 0) -}}
 {{- end -}}
 
-{{- $icon   := $.Scratch.Get "icon" -}}
+{{- $icon := $.Scratch.Get "icon" -}}
 
 <img src="/icons/{{$icon}}.svg" alt="{{$icon}}" class="icons"/>


### PR DESCRIPTION
Prior to this commit, all modifiable values in the style for a platen site were set via SCSS variables; this is useful for override at *build* time but does not allow for easy override at *run* time - ie, with a mode/theme toggle interface.

This commit transitions all SCSS variables, except the name of the game being overridden, to CSS variables.

The name must stay as an SCSS variable for the purposes of being used as a selector instead of a property value